### PR TITLE
Updated to remove dependencies on BLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,11 @@ find_package(ZLIB)
 if (BLE_SUPPORT)
 pkg_search_module(BLZ REQUIRED blzlib)
 add_definitions(-DBLE_SUPPORT)
+add_executable(dfu_ble.c)
 endif (BLE_SUPPORT)
 
 add_executable(nrfdfu main.c log.c util.c serialtty.c
-    dfu.c dfu_serial.c slip.c dfu_ble.c)
+    dfu.c dfu_serial.c slip.c)
 
 target_include_directories(nrfdfu PRIVATE . ${BLZLIB_INCLUDE_DIRS})
 target_link_libraries(nrfdfu ${ZLIB_LIBRARIES} ${LIBZIP_LIBRARIES}

--- a/dfu.c
+++ b/dfu.c
@@ -23,7 +23,9 @@
 
 #include "conf.h"
 #include "dfu.h"
+#ifdef BLE_SUPPORT
 #include "dfu_ble.h"
+#endif
 #include "dfu_serial.h"
 #include "log.h"
 #include "nrf_dfu_handling_error.h"
@@ -73,8 +75,10 @@ static bool send_request(nrf_dfu_request_t* req)
 
 	if (conf.dfu_type == DFU_SERIAL) {
 		return ser_encode_write((uint8_t*)req, size);
+#ifdef BLE_SUPPORT
 	} else {
 		return ble_write_ctrl((uint8_t*)req, size);
+#endif
 	}
 }
 
@@ -171,8 +175,10 @@ static nrf_dfu_response_t* get_response(nrf_dfu_op_t request)
 	const uint8_t* buf = NULL;
 	if (conf.dfu_type == DFU_SERIAL) {
 		buf = ser_read_decode();
+#ifdef BLE_SUPPORT
 	} else {
 		buf = ble_read();
+#endif
 	}
 
 	if (!buf) {
@@ -389,8 +395,10 @@ bool dfu_object_write(zip_file_t* zf, size_t size)
 		bool b;
 		if (conf.dfu_type == DFU_SERIAL) {
 			b = ser_encode_write(buf, len + 1);
+#ifdef BLE_SUPPORT
 		} else {
 			b = ble_write_data(fbuf, len);
+#endif
 		}
 		if (!b) {
 			LOG_ERR("write failed");


### PR DESCRIPTION
I found that when I turned off BLE support, CMAKE refused to compile because it still looked for a bunch off includes. So I added some ifdef's to make it all work nicely.