### PR TITLE
nrfdfu fails to build with BLE_SUPPORT=OFF.

### DIFF
--- a/dfu_ble.c
+++ b/dfu_ble.c
@@ -28,10 +28,15 @@
 
 #ifndef BLE_SUPPORT
 
-bool ble_enter_dfu(const char* interface, const char* address,
+int ble_enter_dfu(const char* interface, const char* address,
 				   enum BLE_ATYPE atype)
 {
 	return false;
+}
+bool ble_connect_dfu_targ(const char* interface, const char* address,
+                                                  enum BLE_ATYPE atype)
+{
+        return false;
 }
 bool ble_write_ctrl(uint8_t* req, size_t len)
 {
@@ -44,6 +49,9 @@ bool ble_write_data(uint8_t* req, size_t len)
 const uint8_t* ble_read(void)
 {
 	return NULL;
+}
+void ble_disconnect(void)
+{
 }
 void ble_fini(void)
 {


### PR DESCRIPTION
08cf00fc224c46dec744df49cea5e5c90a3d5042 and 8221e1fec64c882b3e09e12557c53485ef433198 introduced the functions ```ble_connect_dfu_targ```, ```ble_disconnect``` and changed the return type of ```ble_enter_dfu``` but did not defined/changed this functions in the ```BLE_SUPPORT=OFF``` block of ```dfu_ble.c```. This leads to errors during compilation.