### PR TITLE
make nrfdfu compile on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ endif (BLE_SUPPORT)
 add_executable(nrfdfu main.c log.c util.c serialtty.c
     dfu.c dfu_serial.c slip.c dfu_ble.c)
 
-target_include_directories(nrfdfu PRIVATE . ${BLZLIB_INCLUDE_DIRS})
+target_include_directories(nrfdfu PRIVATE . ${ZLIB_INCLUDE_DIRS}
+    ${LIBZIP_INCLUDE_DIRS} ${JSONC_INCLUDE_DIRS} ${BLZLIB_INCLUDE_DIRS})
 target_link_libraries(nrfdfu ${ZLIB_LIBRARIES} ${LIBZIP_LIBRARIES}
     ${JSONC_LIBRARIES} ${BLZ_LIBRARIES})
 

--- a/dfu.c
+++ b/dfu.c
@@ -17,7 +17,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifdef __APPLE__
+#include "mac_endian.h"
+#else
 #include <endian.h>
+#endif
 
 #include <zlib.h>
 

--- a/mac_endian.h
+++ b/mac_endian.h
@@ -1,0 +1,33 @@
+#ifndef __FINK_ENDIANDEV_PKG_ENDIAN_H__
+#define __FINK_ENDIANDEV_PKG_ENDIAN_H__ 1
+
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * */
+
+#ifndef __APPLE__
+	#warning "This header file (endian.h) is MacOS X specific.\n"
+#endif	/* __APPLE__ */
+
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+
+#endif	/* __FINK_ENDIANDEV_PKG_ENDIAN_H__ */

--- a/serialtty.c
+++ b/serialtty.c
@@ -46,11 +46,13 @@ static void serial_set_tty_speed(int baud)
 		case 57600:		tty.c_cflag |= B57600; break;
 		case 115200:	tty.c_cflag |= B115200; break;
 		case 230400:	tty.c_cflag |= B230400; break;
+#ifndef __APPLE__
 		case 460800:	tty.c_cflag |= B460800; break;
 		case 500000:	tty.c_cflag |= B500000; break;
 		case 576000:	tty.c_cflag |= B576000; break;
 		case 921600:	tty.c_cflag |= B921600; break;
 		case 1000000:	tty.c_cflag |= B1000000; break;
+#endif
 		default:		LOG_ERR("Unknown baudrate %d", baud);
 	}
 	// clang-format on


### PR DESCRIPTION
Make nrfdfu compile on OSX

Tested only without BLE support (`-DBLE_SUPPORT=OFF`) 